### PR TITLE
8 fix deprecated hidden issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <h4>Others</h4>
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.0.20-7f52ff.svg?logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.1.0-7f52ff.svg?logo=kotlin)](https://kotlinlang.org)
 [![Java](https://img.shields.io/badge/Java-8-%23ED8B00.svg?logo=openJdk&logoColor=white)](https://openjdk.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://mit-license.org/)
 
@@ -488,10 +488,9 @@ because the `ACC_SYNTHETIC` doesn't work on them, the flag is applied to all the
 
 ### Kotlin hiding
 
-To effectively hide elements from Kotlin, the plugin generates on the marked elements the
-[@Deprecated](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecated/) annotation. This annotation used with
-the [DeprecationLevel.HIDDEN](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-deprecation-level/-h-i-d-d-e-n.html)
-level, makes the element invisible to Kotlin sources, but still visible to Java sources.
+To effectively hide elements from Kotlin, the plugin changes the elements visibility to `internal` (this is done only if
+the element visibility is greater than `internal`, currently `public` or `protected`). The elements made `internal` in
+this way are not marked with the `ACC_SYNTHETIC` flag to keep them visible from Java sources.
 
 ```kotlin
 // Foo.kt
@@ -504,17 +503,10 @@ class Foo {
 
 // Foo.class
 @HideFromKotlin
-@Deprecated(message = "", level = DeprecationLevel.HIDDEN)
-class Foo {
+internal class Foo {
     // ...
 }
 ```
-
-Generating the `Deprecated` annotation or simply using it directly have slightly different outcomes. Indeed, the
-`Deprecated` annotation (with `HIDDEN` level) acts as a flag for the Kotlin compiler. The latter will add the JVM
-`ACC_SYNTHETIC` flag for the element in the produced classfile, making it also invisible for Java sources. The hack is
-that the Kotlin compiler processing of `Deprecated` annotations runs **before** the compiler plugin runs, so the
-`Deprecated` annotations will not be present at the time the compiler processes the symbols.
 
 ## Future Plans
 
@@ -522,6 +514,14 @@ that the Kotlin compiler processing of `Deprecated` annotations runs **before** 
   symbols of a project to simplify Kotlin project obfuscation with [ProGuard](https://www.guardsquare.com/proguard).
 
 ## Changelog
+
+### 0.1.2 - 2024-12-24
+
+**Bugfixes** :
+
+- Fixed issue where elements annotated with HideFromKotlin were also not accessible from Java Changed due to the
+generation of an `ACC_SYNTHETIC` flag ;
+- Changed the retention policy of the HideFromJava annotation to BINARY, to be consistent with other annotations.
 
 ### 0.1.1 - 2024-10-11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Project information
 projectGroup=com.zwendo
 pluginVersion=0.1.2
-annotationsVersion=0.1.0
+annotationsVersion=0.2.0
 # Dependencies' versions
 jvmVersion=1.8
 junitVersion=5.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project information
 projectGroup=com.zwendo
-pluginVersion=0.1.1
+pluginVersion=0.1.2
 annotationsVersion=0.1.0
 # Dependencies' versions
 jvmVersion=1.8

--- a/restrikt2-annotations/src/main/kotlin/com/zwendo/restrikt2/annotation/Annotations.kt
+++ b/restrikt2-annotations/src/main/kotlin/com/zwendo/restrikt2/annotation/Annotations.kt
@@ -3,9 +3,8 @@ package com.zwendo.restrikt2.annotation
 /**
  * This annotation is used to hide elements from kotlin sources.
  *
- * Used with the [Restrikt compiler plugin](https://github.com/ZwenDo/Restrikt), this annotation causes the retention
- * of the [Deprecated] annotation with the level [DeprecationLevel.HIDDEN], which hides the element for Kotlin sources.
- * However, elements will still be accessible at runtime from compiled Kotlin files.
+ * Used with the [Restrikt compiler plugin](https://github.com/ZwenDo/Restrikt), this annotation causes the element
+ * visibility to be internal (only if the element has a greater visibility).
  *
  * Like [JvmSynthetic] acts to hide elements to Java, this annotation is intended for API designers who want to hide a
  * Java-specific target from Kotlin language, in order to keep an idiomatic API for both languages.

--- a/restrikt2-annotations/src/main/kotlin/com/zwendo/restrikt2/annotation/Annotations.kt
+++ b/restrikt2-annotations/src/main/kotlin/com/zwendo/restrikt2/annotation/Annotations.kt
@@ -40,7 +40,7 @@ annotation class HideFromKotlin
     AnnotationTarget.FILE
 )
 @MustBeDocumented
-@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.BINARY)
 annotation class HideFromJava
 
 /**

--- a/restrikt2-compiler-plugin/src/main/kotlin/com/zwendo/restrikt2/plugin/frontend/RestriktCompilerPluginRegistrar.kt
+++ b/restrikt2-compiler-plugin/src/main/kotlin/com/zwendo/restrikt2/plugin/frontend/RestriktCompilerPluginRegistrar.kt
@@ -1,7 +1,7 @@
 package com.zwendo.restrikt2.plugin.frontend
 
-import com.zwendo.restrikt2.plugin.backend.RestriktPackagePrivateChecker
 import com.zwendo.restrikt2.plugin.backend.RestriktAnnotationProcessor
+import com.zwendo.restrikt2.plugin.backend.RestriktPackagePrivateChecker
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrar
 import org.jetbrains.kotlin.fir.extensions.FirExtensionRegistrarAdapter
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.platform.jvm.isJvm
 
 /**
  * Class that registers plugin custom class generation interceptor

--- a/restrikt2-gradle-plugin/build.gradle.kts
+++ b/restrikt2-gradle-plugin/build.gradle.kts
@@ -1,7 +1,5 @@
-import java.util.Locale
-
 plugins {
-    id("java-gradle-plugin")
+    `java-gradle-plugin`
     val gradlePluginPublishVersion: String by System.getProperties()
     id("com.gradle.plugin-publish") version gradlePluginPublishVersion
 }

--- a/restrikt2-test/build.gradle.kts
+++ b/restrikt2-test/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     kotlin("jvm") version "2.0.20"
-    id("com.zwendo.restrikt2") version "0.1.1"
+    id("com.zwendo.restrikt2") version "0.1.2"
     id("com.github.gmazzo.buildconfig") version "5.5.0"
 }
 

--- a/restrikt2-test/src/test/kotlin/com/zwendo/restrikt2/test/hidefromkotlin/HFKTest.kt
+++ b/restrikt2-test/src/test/kotlin/com/zwendo/restrikt2/test/hidefromkotlin/HFKTest.kt
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KCallable
+import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
 import kotlin.reflect.jvm.javaField
 
 class HFKTest {
@@ -17,16 +20,7 @@ class HFKTest {
 
     @Test
     fun `Annotated property is hidden and message is correctly applied`() {
-        val property = invisiblePropertyAccessor
-        assertTrue(property.isHiddenFromKotlin)
-    }
-
-    @Test
-    fun `Annotated field is hidden and message is correctly applied`() {
-        val property = ::invisibleField
-        property.javaField.assertNotNullAnd {
-            assertTrue(isHiddenFromKotlin)
-        }
+        assertTrue(invisiblePropertyAccessor.isHiddenFromKotlin)
     }
 
     @Test
@@ -47,14 +41,12 @@ class HFKTest {
 
     @Test
     fun `Not annotated method is not hidden`() {
-        val property = visibleFunctionAccessor as KAnnotatedElement
-        assertFalse(property.isHiddenFromKotlin)
+        assertFalse(visibleFunctionAccessor.isHiddenFromKotlin)
     }
 
     @Test
     fun `Annotated method is hidden and message is correctly applied`() {
-        val property = invisibleFunctionAccessor as KAnnotatedElement
-        assertTrue(property.isHiddenFromKotlin)
+        assertTrue(invisibleFunctionAccessor.isHiddenFromKotlin)
     }
 
     @Test
@@ -99,15 +91,14 @@ class HFKTest {
 
     @Test
     fun `Annotated annotation is hidden and message is correctly applied`() {
-        val annotation = invisibleAnnotationAccessor
-        assertTrue(annotation.isHiddenFromKotlin)
+        assertTrue(invisibleAnnotationAccessor.isHiddenFromKotlin)
     }
 
 
-    private val KAnnotatedElement.isHiddenFromKotlin: Boolean
-        get() = annotations.any { it is Deprecated && it.level == DeprecationLevel.HIDDEN }
+    private val KCallable<*>.isHiddenFromKotlin: Boolean
+        get() = visibility == KVisibility.INTERNAL
 
-    private val AnnotatedElement.isHiddenFromKotlin: Boolean
-        get() = annotations.any { it is Deprecated && it.level == DeprecationLevel.HIDDEN }
+    private val KClass<*>.isHiddenFromKotlin: Boolean
+        get() = visibility == KVisibility.INTERNAL
 
 }


### PR DESCRIPTION
The `Deprecated(Hidden)` issue has been fix by using a totally different approach to hide elements from Kotlin. Instead of using `Deprecated`, elements are now made `internal` when they have a greater visibility. 

By doing this, elements cannot be accessed from Kotlin, but because internal visibility does not exist in Java, they remain accessible (this statement is true because the plugin ignores elements with an internal visibility due to the presence of a `HideFromKotlin` annotation).